### PR TITLE
chore: update react version to support 18 and 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "uglify-es": "^3.1.5"
   },
   "peerDependencies": {
-    "react": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0 || ^17.0"
+    "react": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0 || ^17.0 || ^18.0 || ^19.0"
   },
   "scripts": {
     "build": "npm run build:clean && npm run build:lib && npm run build:dist",


### PR DESCRIPTION
The API used in this repo still support by react 18 and 19:
- https://19.react.dev/reference/react/cloneElement
- https://19.react.dev/reference/react/Children#children-only
- lifecycle api: 

https://19.react.dev/reference/react/Component#componentdidmount  https://19.react.dev/reference/react/Component#componentdidupdate
https://19.react.dev/reference/react/Component#componentwillunmount